### PR TITLE
Root prefix

### DIFF
--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -19,6 +19,7 @@ default = []
 prometheus = []
 
 [dependencies]
+Inflector = "0.11"
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = "1.0"

--- a/macros/src/ast.rs
+++ b/macros/src/ast.rs
@@ -27,7 +27,7 @@ impl<'a> Field<'a> {
 
     pub fn get_metric(&self) -> Option<String> {
         match &self.attributes {
-            Attributes::Root(_) => None,
+            Attributes::Root(root) => root.name_override.clone(),
             Attributes::Struct(StructAttributes {
                 hidden,
                 name_override,
@@ -72,6 +72,7 @@ pub enum Attributes {
 #[derive(Default, Debug)]
 pub struct RootAttributes {
     pub separator: Option<String>,
+    pub name_override: Option<String>,
 }
 
 #[derive(Default, Debug)]
@@ -119,6 +120,9 @@ impl Attributes {
                                         NestedMeta::Lit(lit) => {
                                             if let Lit::Str(name) = lit {
                                                 attributes.name_override = Some(name.value());
+                                                if let Some(root) = &mut root {
+                                                    root.name_override = Some(name.value());
+                                                }
                                             }
                                         }
                                     }

--- a/macros/src/metric_scope.rs
+++ b/macros/src/metric_scope.rs
@@ -10,6 +10,7 @@ use syn::{Error, Path, Result};
 #[derive(Debug)]
 pub struct MetricScope {
     pub struct_name: String,
+    pub name_override: Option<String>,
     pub metrics: Vec<MetricInstance>,
     pub sub_metrics: HashMap<String, SubMetric>,
     pub other_fields: HashMap<String, String>,
@@ -98,7 +99,13 @@ impl MetricScope {
         });
 
         let with_strip_prefix = |segment| {
-            if is_root {
+            if is_root
+                && self
+                    .name_override
+                    .as_ref()
+                    .map(|x| !x.is_empty())
+                    .unwrap_or(true)
+            {
                 let prefix = format!("{}{}", self.struct_name.to_snake_case(), key_separator);
                 quote! {
                     name.strip_prefix(#prefix).and_then(|name| {

--- a/macros/src/metric_scope.rs
+++ b/macros/src/metric_scope.rs
@@ -1,4 +1,5 @@
 use crate::ast::TypePath;
+use inflector::Inflector;
 use proc_macro2::Ident;
 use quote::{format_ident, quote};
 use std::collections::HashMap;
@@ -15,9 +16,9 @@ pub struct MetricScope {
 }
 
 impl MetricScope {
-    pub fn generate(&self, key_separator: &str) -> proc_macro2::TokenStream {
+    pub fn generate(&self, key_separator: &str, is_root: bool) -> proc_macro2::TokenStream {
         let initialize = self.generate_init();
-        let registry_trait = self.generate_registry_trait(key_separator);
+        let registry_trait = self.generate_registry_trait(key_separator, is_root);
         #[cfg(feature = "prometheus")]
         let prometheus = self.generate_prometheus(key_separator);
         #[cfg(not(feature = "prometheus"))]
@@ -54,7 +55,11 @@ impl MetricScope {
         }
     }
 
-    fn generate_registry_trait(&self, key_separator: &str) -> proc_macro2::TokenStream {
+    fn generate_registry_trait(
+        &self,
+        key_separator: &str,
+        is_root: bool,
+    ) -> proc_macro2::TokenStream {
         let struct_name = format_ident!("{}", &self.struct_name);
         let counters = match_metric_names(&self.metrics, &[MetricType::Counter], None);
         let sub_counters = self
@@ -92,27 +97,50 @@ impl MetricScope {
             quote! { .or_else(|| name.strip_prefix(#prefix).and_then(|n| ::metrics_catalogue::Registry::find_histogram(&self.#sub, n))) }
         });
 
+        let with_strip_prefix = |segment| {
+            if is_root {
+                let prefix = format!("{}{}", self.struct_name.to_snake_case(), key_separator);
+                quote! {
+                    name.strip_prefix(#prefix).and_then(|name| {
+                        #segment
+                    })
+                }
+            } else {
+                segment
+            }
+        };
+
+        let find_counter = with_strip_prefix(quote! {
+            match name {
+                #(#counters),*
+            }
+            #(#sub_counters)*
+        });
+        let find_gauge = with_strip_prefix(quote! {
+            match name {
+                #(#gauges),*
+            }
+            #(#sub_gauges)*
+        });
+        let find_histogram = with_strip_prefix(quote! {
+            match name {
+                #(#histograms),*
+            }
+            #(#sub_histograms)*
+        });
+
         quote! {
             impl ::metrics_catalogue::Registry for #struct_name {
                 fn find_counter(&self, name: &str) -> Option<&::metrics_catalogue::Counter> {
-                    match name {
-                        #(#counters),*
-                    }
-                    #(#sub_counters)*
+                    #find_counter
                 }
 
                 fn find_gauge(&self, name: &str) -> Option<&dyn ::metrics_catalogue::GaugeMetric> {
-                    match name {
-                        #(#gauges),*
-                    }
-                    #(#sub_gauges)*
+                    #find_gauge
                 }
 
                 fn find_histogram(&self, name: &str) -> Option<&dyn ::metrics_catalogue::HistogramMetric> {
-                    match name {
-                        #(#histograms),*
-                    }
-                    #(#sub_histograms)*
+                    #find_histogram
                 }
             }
         }

--- a/macros/src/metric_tree.rs
+++ b/macros/src/metric_tree.rs
@@ -104,8 +104,22 @@ impl MetricTree {
 
     fn generate_catalogue(&self) -> proc_macro2::TokenStream {
         let root_struct = self.root_scope.clone().expect("No root struct");
-        let root_mod = root_struct.to_snake_case();
-        let prefix = format!("{}{}", root_mod, self.key_separator);
+        let root_scope = self.scopes.get(&root_struct).expect("No root scope");
+        let root_mod = root_scope
+            .name_override
+            .as_ref()
+            .unwrap_or(&root_struct)
+            .to_snake_case();
+        let prefix = if root_mod.is_empty() {
+            String::new()
+        } else {
+            format!("{}{}", root_mod, self.key_separator)
+        };
+        let root_mod = if root_mod.is_empty() {
+            root_struct.to_snake_case()
+        } else {
+            root_mod
+        };
 
         self.generate_scoped_catalogue(&root_mod, &root_struct)
             .generate_prefix_keys(&prefix, &self.key_separator)
@@ -130,6 +144,7 @@ impl MetricTree {
             ));
         }
 
+        let mut name_override = None;
         if let Attributes::Root(root) = &struct_data.attributes {
             self.root_scope.get_or_insert(struct_data.ident.to_string());
             self.key_separator = root
@@ -137,6 +152,7 @@ impl MetricTree {
                 .as_deref()
                 .unwrap_or(DEFAULT_SEPARATOR)
                 .to_string();
+            name_override = root.name_override.clone();
         }
 
         let mut metrics = vec![];
@@ -220,6 +236,7 @@ impl MetricTree {
         }
         let scope = MetricScope {
             struct_name: struct_data.ident.to_string(),
+            name_override,
             metrics,
             sub_metrics,
             other_fields,

--- a/macros/src/metric_tree.rs
+++ b/macros/src/metric_tree.rs
@@ -107,7 +107,7 @@ impl MetricTree {
         let root_mod = root_struct.to_snake_case();
         let prefix = format!("{}{}", root_mod, self.key_separator);
 
-        self.generate_scoped_catalogue("catalogue", &root_struct)
+        self.generate_scoped_catalogue(&root_mod, &root_struct)
             .generate_prefix_keys(&prefix, &self.key_separator)
     }
 

--- a/macros/src/scoped_catalogue.rs
+++ b/macros/src/scoped_catalogue.rs
@@ -9,7 +9,7 @@ pub struct ScopedCatalogue {
 }
 
 impl ScopedCatalogue {
-    fn generate_prefix_keys(&self, prefix: &str, separator: &str) -> TokenStream {
+    pub fn generate_prefix_keys(&self, prefix: &str, separator: &str) -> TokenStream {
         let metric_keys = self.metrics.iter().map(|(k, v)| {
             let key = format_ident!("{}", k);
             let name = format!("{}{}", prefix, v);
@@ -28,9 +28,5 @@ impl ScopedCatalogue {
                 #(#keys)*
             }
         }
-    }
-
-    pub fn generate_namespaced_keys(&self, separator: &str) -> TokenStream {
-        self.generate_prefix_keys("", separator)
     }
 }

--- a/src/prometheus/server.rs
+++ b/src/prometheus/server.rs
@@ -29,6 +29,7 @@ impl Server {
 
     pub fn run(
         self,
+        root_name: &'static str,
         renderer: impl StringRender + Send + Sync + Clone + 'static,
     ) -> Result<ServerFuture, Error> {
         let server = HyperServer::try_bind(&self.listen_address)?;
@@ -38,7 +39,7 @@ impl Server {
                 async move {
                     Ok::<_, Error>(service_fn(move |_| {
                         let mut output = String::new();
-                        renderer.render("", "", &mut output);
+                        renderer.render(root_name, "", &mut output);
                         async move { Ok::<_, Error>(Response::new(Body::from(output))) }
                     }))
                 }

--- a/tests/empty_root_name.rs
+++ b/tests/empty_root_name.rs
@@ -1,0 +1,30 @@
+use metrics_catalogue::*;
+
+#[derive(Catalogue)]
+#[metric(root, "")]
+pub struct EmptyRoot {
+    bar: Bar,
+}
+
+#[derive(Catalogue)]
+pub struct Bar {
+    counter: Counter,
+}
+
+#[test]
+fn empty_override() {
+    let t = EmptyRoot::new();
+    assert_eq!(empty_root::bar::COUNTER, "bar.counter");
+
+    let registered_counters = [(empty_root::bar::COUNTER, &t.bar.counter)];
+    for (key, field) in registered_counters {
+        let pre = field.read();
+        t.increment_counter(&Key::from_name(key), 1);
+        assert_eq!(
+            field.read(),
+            pre + 1,
+            "key {} did not update the counter",
+            key
+        );
+    }
+}

--- a/tests/metrics.rs
+++ b/tests/metrics.rs
@@ -46,34 +46,43 @@ struct SubSubTest {
 #[test]
 fn key_generation() {
     let known_names = [
-        (catalogue::MY_B, "my_b"),
-        (catalogue::MY_G, "my_g"),
-        (catalogue::MY_H_60, "my_h_60"),
-        (catalogue::MY_COUNTER_A, "my_counter_a"),
-        (catalogue::my_test::MY_T_A, "my_test.my_t_a"),
-        (catalogue::my_test::MY_T_B, "my_test.my_t_b"),
-        (catalogue::my_test::MY_T_H, "my_test.my_t_h"),
+        (catalogue::MY_B, "test.my_b"),
+        (catalogue::MY_G, "test.my_g"),
+        (catalogue::MY_H_60, "test.my_h_60"),
+        (catalogue::MY_COUNTER_A, "test.my_counter_a"),
+        (catalogue::my_test::MY_T_A, "test.my_test.my_t_a"),
+        (catalogue::my_test::MY_T_B, "test.my_test.my_t_b"),
+        (catalogue::my_test::MY_T_H, "test.my_test.my_t_h"),
         (
             catalogue::my_test::my_sub_sub::MY_S_T_A,
-            "my_test.my_sub_sub.my_s_t_a",
+            "test.my_test.my_sub_sub.my_s_t_a",
         ),
         (
             catalogue::my_test::my_sub_sub::MY_S_T_B,
-            "my_test.my_sub_sub.my_s_t_b",
+            "test.my_test.my_sub_sub.my_s_t_b",
         ),
-        (catalogue::my_second_test::MY_T_A, "my_second_test.my_t_a"),
-        (catalogue::my_second_test::MY_T_B, "my_second_test.my_t_b"),
-        (catalogue::my_second_test::MY_T_H, "my_second_test.my_t_h"),
+        (
+            catalogue::my_second_test::MY_T_A,
+            "test.my_second_test.my_t_a",
+        ),
+        (
+            catalogue::my_second_test::MY_T_B,
+            "test.my_second_test.my_t_b",
+        ),
+        (
+            catalogue::my_second_test::MY_T_H,
+            "test.my_second_test.my_t_h",
+        ),
         (
             catalogue::my_second_test::my_sub_sub::MY_S_T_A,
-            "my_second_test.my_sub_sub.my_s_t_a",
+            "test.my_second_test.my_sub_sub.my_s_t_a",
         ),
         (
             catalogue::my_second_test::my_sub_sub::MY_S_T_B,
-            "my_second_test.my_sub_sub.my_s_t_b",
+            "test.my_second_test.my_sub_sub.my_s_t_b",
         ),
-        (catalogue::MY_FULL_COUNTER, "my_full_counter"),
-        (catalogue::MY_H_30, "my_h_30"),
+        (catalogue::MY_FULL_COUNTER, "test.my_full_counter"),
+        (catalogue::MY_H_30, "test.my_h_30"),
     ];
     known_names.iter().for_each(|(k, v)| assert_eq!(k, v));
 }
@@ -111,10 +120,10 @@ fn counters() {
 fn hidden_counters() {
     let t = Test::new();
     let hidden_counters = [
-        ("my_non_g", &t._my_non_g),
-        ("my_hidden_sub.my_b", &t._my_hidden_sub.my_t_b),
+        ("test.my_non_g", &t._my_non_g),
+        ("test.my_hidden_sub.my_b", &t._my_hidden_sub.my_t_b),
         (
-            "my_hidden_sub.my_sub_sub.my_s_t_b",
+            "test.my_hidden_sub.my_sub_sub.my_s_t_b",
             &t._my_hidden_sub.my_sub_sub.my_s_t_b,
         ),
     ];

--- a/tests/metrics.rs
+++ b/tests/metrics.rs
@@ -46,43 +46,34 @@ struct SubSubTest {
 #[test]
 fn key_generation() {
     let known_names = [
-        (catalogue::MY_B, "test.my_b"),
-        (catalogue::MY_G, "test.my_g"),
-        (catalogue::MY_H_60, "test.my_h_60"),
-        (catalogue::MY_COUNTER_A, "test.my_counter_a"),
-        (catalogue::my_test::MY_T_A, "test.my_test.my_t_a"),
-        (catalogue::my_test::MY_T_B, "test.my_test.my_t_b"),
-        (catalogue::my_test::MY_T_H, "test.my_test.my_t_h"),
+        (test::MY_B, "test.my_b"),
+        (test::MY_G, "test.my_g"),
+        (test::MY_H_60, "test.my_h_60"),
+        (test::MY_COUNTER_A, "test.my_counter_a"),
+        (test::my_test::MY_T_A, "test.my_test.my_t_a"),
+        (test::my_test::MY_T_B, "test.my_test.my_t_b"),
+        (test::my_test::MY_T_H, "test.my_test.my_t_h"),
         (
-            catalogue::my_test::my_sub_sub::MY_S_T_A,
+            test::my_test::my_sub_sub::MY_S_T_A,
             "test.my_test.my_sub_sub.my_s_t_a",
         ),
         (
-            catalogue::my_test::my_sub_sub::MY_S_T_B,
+            test::my_test::my_sub_sub::MY_S_T_B,
             "test.my_test.my_sub_sub.my_s_t_b",
         ),
+        (test::my_second_test::MY_T_A, "test.my_second_test.my_t_a"),
+        (test::my_second_test::MY_T_B, "test.my_second_test.my_t_b"),
+        (test::my_second_test::MY_T_H, "test.my_second_test.my_t_h"),
         (
-            catalogue::my_second_test::MY_T_A,
-            "test.my_second_test.my_t_a",
-        ),
-        (
-            catalogue::my_second_test::MY_T_B,
-            "test.my_second_test.my_t_b",
-        ),
-        (
-            catalogue::my_second_test::MY_T_H,
-            "test.my_second_test.my_t_h",
-        ),
-        (
-            catalogue::my_second_test::my_sub_sub::MY_S_T_A,
+            test::my_second_test::my_sub_sub::MY_S_T_A,
             "test.my_second_test.my_sub_sub.my_s_t_a",
         ),
         (
-            catalogue::my_second_test::my_sub_sub::MY_S_T_B,
+            test::my_second_test::my_sub_sub::MY_S_T_B,
             "test.my_second_test.my_sub_sub.my_s_t_b",
         ),
-        (catalogue::MY_FULL_COUNTER, "test.my_full_counter"),
-        (catalogue::MY_H_30, "test.my_h_30"),
+        (test::MY_FULL_COUNTER, "test.my_full_counter"),
+        (test::MY_H_30, "test.my_h_30"),
     ];
     known_names.iter().for_each(|(k, v)| assert_eq!(k, v));
 }
@@ -91,16 +82,16 @@ fn key_generation() {
 fn counters() {
     let t = Test::new();
     let registered_counters = [
-        (catalogue::MY_B, &t.my_b),
-        (catalogue::MY_COUNTER_A, &t.my_a),
-        (catalogue::my_test::MY_T_B, &t.my_test.my_t_b),
+        (test::MY_B, &t.my_b),
+        (test::MY_COUNTER_A, &t.my_a),
+        (test::my_test::MY_T_B, &t.my_test.my_t_b),
         (
-            catalogue::my_test::my_sub_sub::MY_S_T_B,
+            test::my_test::my_sub_sub::MY_S_T_B,
             &t.my_test.my_sub_sub.my_s_t_b,
         ),
-        (catalogue::my_second_test::MY_T_B, &t.my_second_test.my_t_b),
+        (test::my_second_test::MY_T_B, &t.my_second_test.my_t_b),
         (
-            catalogue::my_second_test::my_sub_sub::MY_S_T_B,
+            test::my_second_test::my_sub_sub::MY_S_T_B,
             &t.my_second_test.my_sub_sub.my_s_t_b,
         ),
     ];
@@ -138,14 +129,14 @@ fn hidden_counters() {
 fn histograms() {
     let t = Test::new();
     let registered_histograms = [
-        (catalogue::MY_H_60, &t.my_h_60 as &dyn HistogramMetric),
-        (catalogue::MY_H_30, &t.my_h_30 as &dyn HistogramMetric),
+        (test::MY_H_60, &t.my_h_60 as &dyn HistogramMetric),
+        (test::MY_H_30, &t.my_h_30 as &dyn HistogramMetric),
         (
-            catalogue::my_test::MY_T_H,
+            test::my_test::MY_T_H,
             &t.my_test.my_t_h as &dyn HistogramMetric,
         ),
         (
-            catalogue::my_second_test::MY_T_H,
+            test::my_second_test::MY_T_H,
             &t.my_second_test.my_t_h as &dyn HistogramMetric,
         ),
     ];

--- a/tests/root_override.rs
+++ b/tests/root_override.rs
@@ -1,0 +1,18 @@
+use metrics_catalogue::*;
+
+#[derive(Catalogue)]
+#[metric(root, "my_test")]
+pub struct CustomRoot {
+    bar: Bar,
+}
+
+#[derive(Catalogue)]
+pub struct Bar {
+    counter: Counter,
+}
+
+#[test]
+fn root_override() {
+    let _ = CustomRoot::new();
+    assert_eq!(my_test::bar::COUNTER, "my_test.bar.counter");
+}

--- a/tests/separator.rs
+++ b/tests/separator.rs
@@ -14,5 +14,5 @@ pub struct CustomSeparatorBar {
 #[test]
 fn custom_separator() {
     let _ = CustomSeparatorFoo::new();
-    assert_eq!(catalogue::bar::COUNTER, "bar-counter");
+    assert_eq!(catalogue::bar::COUNTER, "custom_separator_foo-bar-counter");
 }

--- a/tests/separator.rs
+++ b/tests/separator.rs
@@ -14,5 +14,8 @@ pub struct CustomSeparatorBar {
 #[test]
 fn custom_separator() {
     let _ = CustomSeparatorFoo::new();
-    assert_eq!(catalogue::bar::COUNTER, "custom_separator_foo-bar-counter");
+    assert_eq!(
+        custom_separator_foo::bar::COUNTER,
+        "custom_separator_foo-bar-counter"
+    );
 }


### PR DESCRIPTION
## General

This PR changes two things:

1. The metric key are now always prefixed with the root name
2. The default root mod for the key catalogue from `catalogue` is now the `snake_case` version of the root struct name

As always, this can be overridden using a string attribute in the `#[metric]` annotation, e.g.
```rust
#[derive(Catalogue)]
#[metric(root, "my_test")]
pub struct CustomRoot {
    bar: Counter,
}

#[allow(non_camel_case_types)]
pub mod my_test {
     pub const BAR: &str = "my_test.bar";
}
```
While an empty name will create the root mod as the struct name, but eliminate the root prefix, e.g.
```rust
#[derive(Catalogue)]
#[metric(root, "")]
pub struct CustomRoot {
    bar: Counter,
}

#[allow(non_camel_case_types)]
pub mod my_test {
    pub const BAR: &str = "bar";
}
``
`
